### PR TITLE
feat: pass replace in useQueryState

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fabiulous/routing",
   "description": "Generates a typed routing mechanist based on a config",
   "private": false,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "files": [
     "dist"

--- a/src/hooks/useDebouncedQueryState.test.tsx
+++ b/src/hooks/useDebouncedQueryState.test.tsx
@@ -50,7 +50,7 @@ describe('useDebouncedQueryState', () => {
 
     vi.runAllTimers();
   
-    expect(customFunction).toHaveBeenLastCalledWith('blank', { name: 'UpdatedTest' }, undefined);
+    expect(customFunction).toHaveBeenLastCalledWith('blank', { name: 'UpdatedTest' }, false);
 
     expect(result.current[0]).toBe('UpdatedTest');
     expect(result.current[1]).toBe('Test');

--- a/src/hooks/useDebouncedQueryState.ts
+++ b/src/hooks/useDebouncedQueryState.ts
@@ -8,7 +8,7 @@ import { Maybe, Routing } from '../types';
 
 
 export const generateUseDebouncedQueryState = <T extends Routing.Config>(context: React.Context<Routing.ContextProps<Routing.RecursiveRoutes<T>>>) => {
-  return <T = string>(name: string, defaultValue?: T, delay: number = 500): [Maybe<T>, Maybe<T>, React.Dispatch<React.SetStateAction<T | undefined>>] => {
+  return <T = string>(name: string, defaultValue?: T, delay: number = 500, replace: boolean = false): [Maybe<T>, Maybe<T>, React.Dispatch<React.SetStateAction<T | undefined>>] => {
     const { go, location } = React.useContext(context);
 
     const timeout = React.useRef<number>();
@@ -21,8 +21,8 @@ export const generateUseDebouncedQueryState = <T extends Routing.Config>(context
     const [value, setValue] = React.useState(query);
   
     const updateHistory = React.useCallback(() => {
-      go({ [name]: value });
-    }, [go, name, value]);
+      go({ [name]: value }, replace);
+    }, [go, name, value, replace]);
   
     React.useEffect(
       () => {

--- a/src/hooks/useQueryState.test.tsx
+++ b/src/hooks/useQueryState.test.tsx
@@ -44,6 +44,30 @@ describe('useQueryState', () => {
       result.current[1]('UpdatedTest');
     });
 
-    expect(customFunction).toHaveBeenLastCalledWith('blank', { name: 'UpdatedTest' }, undefined );
+    expect(customFunction).toHaveBeenLastCalledWith('blank', { name: 'UpdatedTest' }, false );
+  })
+
+  test('Should send replace false to go function', () => {
+    const { result } = renderHook(() => useQueryState('name'), { wrapper });
+
+    expect(result.current[0]).toBe('Test');
+
+    act(() => {
+      result.current[1]('UpdatedTest', false);
+    });
+
+    expect(customFunction).toHaveBeenLastCalledWith('blank', { name: 'UpdatedTest' }, false );
+  })
+
+  test('Should send replace true to go function', () => {
+    const { result } = renderHook(() => useQueryState('name'), { wrapper });
+
+    expect(result.current[0]).toBe('Test');
+
+    act(() => {
+      result.current[1]('UpdatedTest', true);
+    });
+
+    expect(customFunction).toHaveBeenLastCalledWith('blank', { name: 'UpdatedTest' }, true );
   })
 });

--- a/src/hooks/useQueryState.ts
+++ b/src/hooks/useQueryState.ts
@@ -6,13 +6,13 @@ import { Maybe, MaybeNull, Routing } from '../types';
 
 
 export const generateUseQueryState = <T extends Routing.Config>(context: React.Context<Routing.ContextProps<Routing.RecursiveRoutes<T>>>) => {
-  return <T = string>(name: string, defaultValue?: T): [Maybe<T>, (value?: MaybeNull<T>) => void] => {
+  return <T = string>(name: string, defaultValue?: T): [Maybe<T>, (value?: MaybeNull<T>, replace?: boolean) => void] => {
     const { go, location } = React.useContext(context);
 
     const value = React.useMemo(() => location ? parseQuery(location.search)[name] as Maybe<T> : undefined, [location, name]);
 
-    const setValue = React.useCallback((value?: MaybeNull<T>) => {
-      go({ [name]: value });
+    const setValue = React.useCallback((value?: MaybeNull<T>, replace: boolean = false) => {
+      go({ [name]: value }, replace);
     }, [go, name]);
     
 

--- a/src/hooks/useRouter.test.tsx
+++ b/src/hooks/useRouter.test.tsx
@@ -35,5 +35,6 @@ describe('useRouter', () => {
   
     expect(result.current.home.path).toBe(router.home.path);
     expect(result.current.auth.login.path).toBe(router.auth.login.path);
+    expect(result.current.users.editTab(1, 'test').path).toBe(router.users.editTab(1, 'test').path);
   })
 });

--- a/src/routing.test.ts
+++ b/src/routing.test.ts
@@ -17,6 +17,8 @@ describe('generateRouter testing', () => {
     expect(editResult.path).toBe('/users/edit/:userId');
     const editResultWithId = result.users.edit(1);
     expect(editResultWithId.path).toBe('/users/edit/1');
+    const editResultWithIdAndTab = result.users.editTab(1, 'test');
+    expect(editResultWithIdAndTab.path).toBe('/users/edit/1/test');
   })
 
   test('Route go', () => {

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -11,8 +11,8 @@ const generateRoute = <T extends Routing.Routes> (fn: (path: string, params: May
   }
 
   if (typeof route === 'function') {
-    return args => {
-      const routeResult = route(args);
+    return (...args) => {
+      const routeResult = route(...args);
 
       if (typeof routeResult === 'string') {
         const path = `${basePath}${routeResult}`;

--- a/src/tests/mocks.ts
+++ b/src/tests/mocks.ts
@@ -11,6 +11,7 @@ export const routes = {
     routes: {
       create: '/create',
       edit: (userId: string | number = ':userId') => `/edit/${userId}`,
+      editTab: (userId: string | number = ':userId', tab: string) => `/edit/${userId}/${tab}`,
       view: (userId: string | number = ':userId') => ({
         path: `/${userId}`,
         routes: {


### PR DESCRIPTION
fix: pass all arguments to go fn